### PR TITLE
Fix README import

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm install @chicowall/grf-loader
 
 ```ts
 import {GrfNode} from 'grf-loader';
-import {openSync} from 'path';
+import {openSync} from 'fs';
 
 const fd = openSync('path/to/data.grf', 'r');
 const grf = new GrfNode(fd);


### PR DESCRIPTION
## Summary
- fix example import to use `fs.openSync`

## Testing
- `npx tsc /tmp/testopen.ts --lib es2015` *(fails: Cannot find module 'fs' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6842e79f42d08330b76dbd4ff11599c4