### PR TITLE
Fix browser test variable name

### DIFF
--- a/cypress/integration/grfbrowser.js
+++ b/cypress/integration/grfbrowser.js
@@ -18,7 +18,7 @@ const getGrfBlob = (name: string) =>
 
 describe('GRFBrowser', () => {
   it('Should not load corrupted file', async () => {
-    const buffer = await getGrfBlob('corrupted.grf');
+    const blob = await getGrfBlob('corrupted.grf');
     let error = '';
     try {
       const grf = new GrfBrowser(blob);


### PR DESCRIPTION
## Summary
- fix variable name in Cypress test for corrupted file

## Testing
- `yarn test:browser` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6842e91128dc8330b696c25e3ae2573b