### PR TITLE
Add extraction example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,14 @@ const {data, error} = await grf.getFile('data\\clientinfo.xml');
 const content = String.fromCharCode.apply(null, data);
 console.log(content);
 ```
+
+### Extract all files
+
+A sample script is provided in `examples/extract-all.ts` to dump every file from a GRF.
+Run it with [ts-node](https://typestrong.org/ts-node/) passing the GRF path and an optional output directory:
+
+```bash
+npx ts-node examples/extract-all.ts path/to/data.grf output-directory
+```
+
+All files will be written under `output-directory` (defaults to `output`).

--- a/examples/extract-all.ts
+++ b/examples/extract-all.ts
@@ -1,0 +1,33 @@
+import {GrfNode} from '../src/grf-node';
+import {openSync, mkdirSync, writeFileSync} from 'fs';
+import {dirname, join} from 'path';
+
+async function main() {
+  const [grfPath, outDir = 'output'] = process.argv.slice(2);
+  if (!grfPath) {
+    console.error(
+      'Usage: ts-node examples/extract-all.ts <path/to.grf> [outputDir]'
+    );
+    process.exit(1);
+  }
+
+  const fd = openSync(grfPath, 'r');
+  const grf = new GrfNode(fd);
+  await grf.load();
+
+  for (const [path, _] of grf.files) {
+    const {data, error} = await grf.getFile(path);
+    if (error || !data) {
+      console.error(`Failed to extract ${path}: ${error}`);
+      continue;
+    }
+    const dest = join(outDir, path);
+    mkdirSync(dirname(dest), {recursive: true});
+    writeFileSync(dest, Buffer.from(data));
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- create `extract-all.ts` example to dump every GRF file
- document how to use it

## Testing
- `npm test` *(fails: package isn't in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6842ea33ee6483309ebb941195e1421f