### PR TITLE
Separate CJS/ESM build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,16 @@
   "type": "module",
   "version": "1.0.6",
   "description": "A loader for GRF files (Ragnarok Online game file)",
-  "main": "./dist/cjs/grf-loader.js",
+  "main": "./dist/cjs/grf-loader.cjs",
   "module": "./dist/esm/grf-loader.js",
+  "exports": {
+    "import": "./dist/esm/grf-loader.js",
+    "require": "./dist/cjs/grf-loader.cjs"
+  },
+  "types": "./dist/types/index.d.ts",
   "sideEffects": false,
   "browser": {
-    "./dist/cjs/grf-loader.js": "./dist/umd/grf-loader.js"
+    "./dist/cjs/grf-loader.cjs": "./dist/umd/grf-loader.js"
   },
   "files": [
     "dist/",
@@ -21,8 +26,8 @@
     "test:browser": "cypress run",
     "test": "yarn test:node --detectOpenHandles && yarn test:browser",
     "lint": "tsc -p tsconfig.json --noEmit",
-    "build": "tsup src/index.ts --dts --format cjs,esm,iife --globalName GrfLoader --sourcemap --minify --clean",
-    "all_config": "yarn lint &&  yarn test:node && yarn test:browser && yarn build"
+    "build": "tsup",
+    "all_config": "yarn lint && yarn test:node && yarn test:browser && yarn build"
   },
   "author": "Vincent Thibault <vthibault.mobile@gmail.com>",
   "license": "MIT",

--- a/tests/exports.test.js
+++ b/tests/exports.test.js
@@ -1,0 +1,12 @@
+describe('package entry points', () => {
+  it('can be imported using ESM', async () => {
+    const mod = await import('../dist/esm/grf-loader.js');
+    expect(mod.GrfBrowser).toBeDefined();
+  });
+
+  it('can be required using CJS', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const mod = require('../dist/cjs/grf-loader.cjs');
+    expect(mod.GrfBrowser).toBeDefined();
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: {
+      entry: 'src/index.ts',
+      outDir: 'dist/types'
+    },
+    outDir: 'dist/esm',
+    sourcemap: true,
+    minify: true,
+    clean: true
+  },
+  {
+    entry: ['src/index.ts'],
+    format: ['cjs'],
+    outDir: 'dist/cjs',
+    sourcemap: true,
+    minify: true,
+    clean: false,
+    outExtension: () => ({ js: '.cjs' })
+  },
+  {
+    entry: ['src/index.ts'],
+    format: ['iife'],
+    globalName: 'GrfLoader',
+    outDir: 'dist/umd',
+    sourcemap: true,
+    minify: true,
+    clean: false
+  }
+]);


### PR DESCRIPTION
## Summary
- configure `tsup` to output ESM and CJS builds in dedicated folders
- publish typings from `dist/types`
- add export map for `import`/`require`
- rename CJS output to `.cjs`
- test that both import and require resolve

## Testing
- `npm test` *(fails: package not in lockfile)*
- `npm run build` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848e7b2f9508330b63189e9c9fd2be5